### PR TITLE
feat: add live provider mode with MoltPe MCP forwarding

### DIFF
--- a/mcp-server/.env.example
+++ b/mcp-server/.env.example
@@ -1,0 +1,9 @@
+# MCP Payment Server configuration
+PORT=3000
+AUTH_ENABLED=false
+RATE_LIMIT=60
+
+# Live mode: forward tool calls to MoltPe's production MCP server
+# PROVIDER_MODE=live
+# MOLTPE_MCP_URL=https://moltpe.com/mcp
+# MOLTPE_AGENT_TOKEN=swai_your_agent_token

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -97,6 +97,22 @@ Or with docker-compose:
 docker-compose up
 ```
 
+## Connect to Live
+
+By default, the server runs with mock providers — no real money, no real transactions.
+
+To connect to MoltPe's production MCP server:
+
+```bash
+PROVIDER_MODE=live \
+MOLTPE_AGENT_TOKEN=swai_your_agent_token \
+npm start
+```
+
+In live mode, all tool calls forward to moltpe.com/mcp. Transactions settle in real USDC on Polygon PoS or Base.
+
+Get an agent token: visit moltpe.com/dashboard to create an agent and copy its API key.
+
 ## Environment Variables
 
 | Variable | Default | Description |
@@ -104,6 +120,9 @@ docker-compose up
 | PORT | 3000 | Server port |
 | AUTH_ENABLED | false | Require bearer token authentication |
 | RATE_LIMIT | 60 | Max requests per minute per IP |
+| PROVIDER_MODE | mock | `mock` for simulated data, `live` for real MCP forwarding |
+| MOLTPE_MCP_URL | https://moltpe.com/mcp | MCP server URL for live mode |
+| MOLTPE_AGENT_TOKEN | — | Agent bearer token (required for live mode) |
 
 ## Examples
 

--- a/mcp-server/docker-compose.yml
+++ b/mcp-server/docker-compose.yml
@@ -6,3 +6,7 @@ services:
     environment:
       - PROVIDER=all
       - AUTH_ENABLED=false
+      # Uncomment for live mode:
+      # - PROVIDER_MODE=live
+      # - MOLTPE_AGENT_TOKEN=swai_your_agent_token
+      # - MOLTPE_MCP_URL=https://moltpe.com/mcp

--- a/mcp-server/public/index.html
+++ b/mcp-server/public/index.html
@@ -68,6 +68,33 @@ body {
   letter-spacing: 0.04em;
 }
 .header-right { display: flex; align-items: center; gap: 12px; flex-shrink: 0; }
+.mode-badge {
+  font-size: 10px;
+  padding: 2px 8px;
+  border-radius: var(--r-badge);
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+.mode-badge .mode-dot {
+  width: 6px; height: 6px;
+  border-radius: 50%;
+}
+.mode-mock { background: rgba(34,197,94,0.15); color: var(--success); border: 1px solid rgba(34,197,94,0.3); }
+.mode-mock .mode-dot { background: var(--success); }
+.mode-live { background: rgba(239,68,68,0.15); color: var(--error); border: 1px solid rgba(239,68,68,0.3); }
+.mode-live .mode-dot { background: var(--error); }
+.live-warning {
+  background: rgba(239,68,68,0.08);
+  border: 1px solid rgba(239,68,68,0.2);
+  border-radius: var(--r-input);
+  padding: 8px 12px;
+  font-size: 11px;
+  color: var(--error);
+  margin: 0 20px;
+  flex-shrink: 0;
+}
 .npm-badge {
   font-size: 10px;
   padding: 2px 7px;
@@ -898,6 +925,7 @@ select { cursor: pointer; }
     <span class="ref-badge">Reference Implementation</span>
   </div>
   <div class="header-right">
+    <span class="mode-badge" id="modeBadge" style="display:none"></span>
     <a class="npm-badge" href="https://www.npmjs.com/package/@moltpe/mcp-payments" target="_blank" rel="noopener">@moltpe/mcp-payments</a>
     <a class="gh-link" href="https://github.com/umangbuilds/moltpe-agent-payments" target="_blank" rel="noopener">
       <svg class="gh-icon" viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
@@ -1956,16 +1984,34 @@ document.getElementById('toolMobileSelect').addEventListener('change', function(
 });
 
 // ── Load tools ────────────────────────────────────────────────────────────────
+// Fetch provider mode and show badge
+fetch('/api/mode')
+  .then(function(r) { return r.json(); })
+  .then(function(data) {
+    var badge = document.getElementById('modeBadge');
+    var isLive = data.mode === 'live';
+    badge.className = 'mode-badge ' + (isLive ? 'mode-live' : 'mode-mock');
+    badge.innerHTML = '<span class="mode-dot"></span>' + (isLive ? 'Live' : 'Mock');
+    badge.style.display = 'inline-flex';
+
+    if (isLive) {
+      var warn = document.createElement('div');
+      warn.className = 'live-warning';
+      warn.textContent = 'Live mode: transactions use real USDC on-chain.';
+      var header = document.querySelector('.site-header');
+      header.parentNode.insertBefore(warn, header.nextSibling);
+    }
+  })
+  .catch(function() { /* mode endpoint not available, hide badge */ });
+
 fetch('/api/tools')
   .then(function(r) { return r.json(); })
   .then(function(tools) {
     S.tools = tools;
-    // Default tab
     switchTab('x402');
     setStatus('ok', tools.length + ' tools loaded');
   })
   .catch(function() {
-    // Tools API failed — use built-in list
     S.tools = Object.keys(TOOL_DESCS).map(function(name) {
       return { name: name, description: TOOL_DESCS[name] };
     });

--- a/mcp-server/server.js
+++ b/mcp-server/server.js
@@ -5,6 +5,7 @@
 const PACKAGE_META = { origin: 'moltpe-agent-payments', author: 'umangbuilds', first_published: '2026-04-06', license: 'Apache-2.0', home: 'https://github.com/umangbuilds/moltpe-agent-payments' };
 
 const http = require('http');
+const https = require('https');
 const fs = require('fs');
 const path = require('path');
 const { loadTools } = require('./tools/index.js');
@@ -15,6 +16,17 @@ const { createRateLimiter } = require('./middleware/rate-limit.js');
 const PORT = parseInt(process.env.PORT || '3000', 10);
 const AUTH_ENABLED = process.env.AUTH_ENABLED === 'true';
 const RATE_LIMIT = parseInt(process.env.RATE_LIMIT || '60', 10);
+const PROVIDER_MODE = process.env.PROVIDER_MODE || 'mock';
+if (!['mock', 'live'].includes(PROVIDER_MODE)) {
+  console.error(`Invalid PROVIDER_MODE: ${PROVIDER_MODE}. Valid: mock, live`);
+  process.exit(1);
+}
+const MOLTPE_MCP_URL = process.env.MOLTPE_MCP_URL || 'https://moltpe.com/mcp';
+const MOLTPE_AGENT_TOKEN = process.env.MOLTPE_AGENT_TOKEN || '';
+if (PROVIDER_MODE === 'live' && !MOLTPE_AGENT_TOKEN) {
+  console.error('PROVIDER_MODE=live requires MOLTPE_AGENT_TOKEN to be set. Exiting.');
+  process.exit(1);
+}
 
 function parseProviderFlag() {
   const flagIndex = process.argv.indexOf('--provider');
@@ -92,6 +104,72 @@ async function handleToolsCall(id, params) {
   }
 }
 
+// Forward a tool call to the live MoltPe MCP server
+async function forwardToLiveMcp(toolName, args) {
+  const rpcBody = JSON.stringify({
+    jsonrpc: '2.0',
+    id: Date.now(),
+    method: 'tools/call',
+    params: { name: toolName, arguments: args }
+  });
+
+  const url = new URL(MOLTPE_MCP_URL);
+  const options = {
+    hostname: url.hostname,
+    port: url.port || (url.protocol === 'https:' ? 443 : 80),
+    path: url.pathname,
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Content-Length': Buffer.byteLength(rpcBody),
+      'Authorization': `Bearer ${MOLTPE_AGENT_TOKEN}`
+    }
+  };
+
+  const transport = url.protocol === 'https:' ? https : http;
+
+  return new Promise((resolve, reject) => {
+    const mcpReq = transport.request(options, (mcpRes) => {
+      const chunks = [];
+      mcpRes.on('data', chunk => chunks.push(chunk));
+      mcpRes.on('end', () => {
+        const raw = Buffer.concat(chunks).toString();
+        try {
+          const parsed = JSON.parse(raw);
+          if (parsed.error) {
+            reject(new Error(parsed.error.message || 'MCP server error'));
+          } else if (parsed.result && parsed.result.content) {
+            // Extract text content from MCP response
+            const textContent = parsed.result.content.find(c => c.type === 'text');
+            if (textContent) {
+              try { resolve(JSON.parse(textContent.text)); }
+              catch { resolve({ raw: textContent.text }); }
+            } else {
+              resolve(parsed.result);
+            }
+          } else {
+            resolve(parsed.result || parsed);
+          }
+        } catch {
+          reject(new Error('Invalid response from MCP server'));
+        }
+      });
+    });
+
+    mcpReq.on('error', (err) => {
+      reject(new Error(`Could not reach MCP server: ${err.message}`));
+    });
+
+    mcpReq.setTimeout(15000, () => {
+      mcpReq.destroy();
+      reject(new Error('MCP server request timed out'));
+    });
+
+    mcpReq.write(rpcBody);
+    mcpReq.end();
+  });
+}
+
 const server = http.createServer(async (req, res) => {
   // CORS headers
   res.setHeader('Access-Control-Allow-Origin', '*');
@@ -115,6 +193,13 @@ const server = http.createServer(async (req, res) => {
   if (req.method === 'GET' && req.url === '/') {
     res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
     res.end(DEMO_HTML);
+    return;
+  }
+
+  // API: current provider mode
+  if (req.method === 'GET' && req.url === '/api/mode') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ mode: PROVIDER_MODE }));
     return;
   }
 
@@ -153,8 +238,39 @@ const server = http.createServer(async (req, res) => {
       res.end(JSON.stringify({ error: `Unknown tool: ${toolName}` }));
       return;
     }
-    // Inject provider into args so tools that check args.provider route correctly
     const enrichedArgs = preferredProvider ? { ...args, provider: preferredProvider } : args;
+
+    // Live mode: forward tool call to MoltPe MCP server
+    if (PROVIDER_MODE === 'live') {
+      if (!MOLTPE_AGENT_TOKEN) {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          request: { tool: toolName, args: enrichedArgs },
+          error: 'Set MOLTPE_AGENT_TOKEN env var to use live mode',
+          timestamp: new Date().toISOString()
+        }));
+        return;
+      }
+      try {
+        const result = await forwardToLiveMcp(toolName, enrichedArgs);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          request: { tool: toolName, args: enrichedArgs },
+          response: result,
+          timestamp: new Date().toISOString()
+        }));
+      } catch (err) {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          request: { tool: toolName, args: enrichedArgs },
+          error: err.message,
+          timestamp: new Date().toISOString()
+        }));
+      }
+      return;
+    }
+
+    // Mock mode: use local providers
     try {
       const result = await tool.handler(enrichedArgs, router);
       res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -247,7 +363,10 @@ const server = http.createServer(async (req, res) => {
 });
 
 server.listen(PORT, () => {
-  console.log(`MCP Payment Server running on port ${PORT} (provider: ${providerName})`);
+  console.log(`MCP Payment Server running on port ${PORT} (provider: ${providerName}, mode: ${PROVIDER_MODE})`);
+  if (PROVIDER_MODE === 'live') {
+    console.log(`  Live mode: forwarding to ${MOLTPE_MCP_URL}`);
+  }
 });
 
 module.exports = { server };


### PR DESCRIPTION
## Summary
- Added `PROVIDER_MODE=live` env var to forward tool calls to MoltPe's production MCP server
- New `GET /api/mode` route returns current mode (mock or live)
- `forwardToLiveMcp()` sends JSON-RPC requests with Bearer auth and 15s timeout
- Startup validation: rejects invalid PROVIDER_MODE, exits if token missing in live mode
- UI shows mock (green) or live (red) mode badge in header with warning banner
- Added `.env.example` with all 6 env vars and updated `docker-compose.yml`
- Updated `mcp-server/README.md` with "Connect to Live" section and env vars table

## Test plan
- [x] All 53 tests pass (tests use mock mode, unaffected)
- [x] Code review: startup validation and .env.example added per review feedback
- [ ] Manual: verify mock mode badge shows green dot
- [ ] Manual: verify `PROVIDER_MODE=live` without token exits with clear error
- [ ] Manual: verify `PROVIDER_MODE=invalid` exits with clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)