### PR TITLE
docs(examples): add LangChain agent integration example (closes #6)

### DIFF
--- a/examples/langchain/README.md
+++ b/examples/langchain/README.md
@@ -1,0 +1,89 @@
+# LangChain × MoltPe — agent payments via MCP
+
+A LangGraph ReAct agent that uses the MoltPe MCP server's payment tools
+to check balances, create invoices, and send payments — without
+human intervention. Runs end-to-end against the mock provider so no
+real funds and no real x402 settlement happen.
+
+Closes [#6](https://github.com/umangbuilds/moltpe-agent-payments/issues/6).
+
+## What it shows
+
+An LLM-driven agent reasoning about three payment tasks back-to-back:
+
+1. **Balance check** — call `check_balance` and report results across providers.
+2. **Invoice creation** — call `create_invoice` for a billed party.
+3. **Payment send** — route a USDC payment via `send_payment` on the stablecoin provider.
+
+The agent picks the right tool for each task based on the prompt and the
+auto-generated tool descriptions, demonstrating that MoltPe's MCP surface
+is directly usable from the LangChain stack.
+
+## Setup (under 5 minutes)
+
+### 1. Start the MoltPe MCP server (mock mode)
+
+In one terminal:
+
+```bash
+cd ../../mcp-server
+npm install
+PROVIDER_MODE=mock npm start -- --provider all
+```
+
+Server listens on `http://localhost:3000/`. Mock mode means seeded balances,
+no real settlement.
+
+### 2. Install Python deps and run the example
+
+In another terminal:
+
+```bash
+cd examples/langchain
+pip install -r requirements.txt
+export OPENAI_API_KEY=sk-...        # for the LLM driving the agent
+python main.py
+```
+
+That's it. Expected output: three demo turns with tool calls visible and a
+final summary from the agent each time.
+
+## Configuration
+
+| Env var            | Default                  | Purpose                                                                     |
+| ------------------ | ------------------------ | --------------------------------------------------------------------------- |
+| `MOLTPE_MCP_URL`   | `http://localhost:3000/` | MCP server endpoint                                                          |
+| `AGENT_ID`         | `agent-alice`            | Sender agent ID (seeded in `mcp-server/providers/seed-data.js`)             |
+| `COUNTERPARTY_ID`  | `agent-bob`              | Receiver agent ID (also seeded)                                              |
+| `OPENAI_MODEL`     | `gpt-4o-mini`            | LLM model name                                                               |
+| `OPENAI_API_KEY`   | (required)               | LLM credentials                                                              |
+
+> Note: the **MoltPe payment side runs without credentials** in mock mode.
+> The `OPENAI_API_KEY` is only for the LLM that drives the LangChain agent;
+> swap the `langchain_openai` import + `ChatOpenAI` line in `main.py` for
+> any other LangChain chat model (Anthropic, Bedrock, local Ollama, etc.)
+> if you'd rather not use OpenAI.
+
+## Files
+
+- `main.py` — async ReAct agent wiring `langchain-mcp-adapters` →
+  `MultiServerMCPClient` → MoltPe.
+- `requirements.txt` — `langchain-mcp-adapters`, `langchain-openai`, `langgraph`.
+
+## Acceptance-criteria mapping (issue #6)
+
+- [x] **Agent can call check_balance, send_payment, and create_invoice** —
+      all three exercised in the three demo prompts in `main.py`.
+- [x] **Example runs with `python main.py`** — single async entry point.
+- [x] **README explains setup in under 5 minutes** — two terminals,
+      three commands each.
+- [x] **Works with the mock provider (no real credentials needed)** for the
+      payment side. LLM credentials are documented separately and the
+      adapter pattern lets users swap in any LangChain chat model.
+
+## What's next
+
+The companion [issue #7](https://github.com/umangbuilds/moltpe-agent-payments/issues/7)
+covers an AutoGen multi-agent flow — same MCP surface, two cooperating
+agents (one earning, one paying). Same `langchain-mcp-adapters` pattern
+generalises with AutoGen's tool registration if you want to follow up.

--- a/examples/langchain/main.py
+++ b/examples/langchain/main.py
@@ -1,0 +1,102 @@
+"""LangChain agent talking to MoltPe MCP tools.
+
+Wires the MoltPe MCP server (Streamable-HTTP transport at localhost:3000)
+into a LangGraph ReAct agent so an LLM can autonomously call
+``check_balance``, ``send_payment``, and ``create_invoice``.
+
+Designed to run end-to-end against the mock provider — no real funds, no
+real x402 settlement. Set ``OPENAI_API_KEY`` (or swap the LLM block below
+for a different provider) and the agent is ready.
+
+Usage:
+    # 1. Start the MoltPe MCP server in another terminal:
+    cd ../../mcp-server
+    PROVIDER_MODE=mock npm start -- --provider all
+
+    # 2. Run this example:
+    pip install -r requirements.txt
+    export OPENAI_API_KEY=...
+    python main.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from langchain_openai import ChatOpenAI
+from langgraph.prebuilt import create_react_agent
+
+MCP_URL = os.environ.get("MOLTPE_MCP_URL", "http://localhost:3000/")
+# Default to a seeded mock agent so the example runs end-to-end without
+# any setup. See mcp-server/providers/seed-data.js for the canonical list
+# (alice, bob, charlie).
+AGENT_ID = os.environ.get("AGENT_ID", "agent-alice")
+COUNTERPARTY_ID = os.environ.get("COUNTERPARTY_ID", "agent-bob")
+MODEL = os.environ.get("OPENAI_MODEL", "gpt-4o-mini")
+
+
+SYSTEM_PROMPT = (
+    "You are a payment-aware AI agent. You have access to MCP tools that let "
+    "you check your balance, send payments to other agents, and create "
+    f"invoices. Your agent ID is `{AGENT_ID}`. When asked to perform a "
+    "payment task, use the tools rather than guessing. After each tool "
+    "call, summarise the result in plain language."
+)
+
+
+async def run() -> None:
+    if not os.environ.get("OPENAI_API_KEY"):
+        raise RuntimeError(
+            "OPENAI_API_KEY is required to run the LangChain agent. "
+            "The MoltPe MCP server itself runs in mock mode without "
+            "credentials, but the LLM driving the agent does need one."
+        )
+
+    client = MultiServerMCPClient(
+        {
+            "moltpe": {
+                "url": MCP_URL,
+                "transport": "streamable_http",
+            }
+        }
+    )
+
+    tools = await client.get_tools()
+    print(f"Loaded {len(tools)} MoltPe MCP tools:")
+    for t in tools:
+        print(f"  • {t.name} — {t.description[:80]}")
+    print()
+
+    agent = create_react_agent(
+        ChatOpenAI(model=MODEL, temperature=0),
+        tools,
+    )
+
+    prompts = [
+        f"What's my current balance across all payment rails? My agent id is {AGENT_ID}.",
+        f"Create an invoice for 25 USDC billed to {COUNTERPARTY_ID}. "
+        f"Description: 'monthly API access'. I am {AGENT_ID}.",
+        f"Send 10 USDC from {AGENT_ID} to {COUNTERPARTY_ID} via the stablecoin "
+        f"provider on the base chain.",
+    ]
+
+    for i, prompt in enumerate(prompts, start=1):
+        print(f"━━━ Demo step {i}/{len(prompts)} ━━━")
+        print(f"USER: {prompt}\n")
+        result = await agent.ainvoke(
+            {
+                "messages": [
+                    {"role": "system", "content": SYSTEM_PROMPT},
+                    {"role": "user", "content": prompt},
+                ]
+            }
+        )
+        final = result["messages"][-1]
+        content = getattr(final, "content", None) or final.get("content", "")
+        print(f"AGENT: {content}\n")
+
+
+if __name__ == "__main__":
+    asyncio.run(run())

--- a/examples/langchain/requirements.txt
+++ b/examples/langchain/requirements.txt
@@ -1,0 +1,3 @@
+langchain-mcp-adapters>=0.1.0
+langchain-openai>=0.2.0
+langgraph>=0.2.0


### PR DESCRIPTION
## Summary

Closes #6.

Adds `examples/langchain/` with a LangGraph ReAct agent wired to the MoltPe MCP server through `langchain-mcp-adapters`. Three end-to-end demo turns exercise `check_balance`, `create_invoice`, and `send_payment` so a reader can see one tool call per acceptance-criteria item.

## What's in the directory

| File | Purpose |
|---|---|
| `main.py` | Async entry point. Loads tools via `MultiServerMCPClient`, builds a `create_react_agent`, runs three demo prompts. |
| `requirements.txt` | `langchain-mcp-adapters`, `langchain-openai`, `langgraph` — minimal, all on PyPI. |
| `README.md` | Two-terminal setup (≤5 min), env-var table, acceptance-criteria mapping. |

## Decisions worth flagging

- **Defaults to seeded agents.** `AGENT_ID=agent-alice`, `COUNTERPARTY_ID=agent-bob`. Both are seeded in `mcp-server/providers/seed-data.js`, so a clone-and-run user gets meaningful results from the first prompt instead of `Unknown agent: ...` errors. README documents how to override.
- **Streamable HTTP transport.** Server.js exposes JSON-RPC 2.0 on `POST /` (lines 173–360); `langchain-mcp-adapters` connects via `transport: "streamable_http"`. Verified locally with `curl POST` round-trips against `tools/list` and `tools/call`.
- **LLM is swappable.** README explicitly notes the MoltPe side runs without credentials (mock provider); the only credential needed is for the LLM driving the agent, and the import + one line in `main.py` swaps `ChatOpenAI` for any LangChain chat model.

## Acceptance-criteria check

- [x] Agent can call `check_balance`, `send_payment`, `create_invoice` — one prompt each.
- [x] Example runs with `python main.py`.
- [x] README explains setup in under 5 minutes.
- [x] Works with the mock provider — no real credentials on the payment side.

## Tested locally

```
$ PROVIDER_MODE=mock node mcp-server/server.js --provider all  # in another terminal
$ curl -s http://localhost:3000/health
{"status":"ok","provider":"all"}
$ curl -s -X POST http://localhost:3000/ -H 'Content-Type: application/json' \
    -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | jq '.result.tools | length'
11
$ curl -s -X POST http://localhost:3000/ -H 'Content-Type: application/json' \
    -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"check_balance","arguments":{"agentId":"agent-alice"}}}' | jq '.result.content[0].text' | head
```

All 11 tools enumerate; `tools/call check_balance` returns the seeded multi-rail balances for `agent-alice` cleanly. Couldn't run `python main.py` end-to-end against an LLM here (no OPENAI_API_KEY available in this env) — flagging that explicitly so reviewers can run the LLM round-trip.

## Follow-up

Happy to ship the AutoGen counterpart at #7 next; the same `langchain-mcp-adapters` pattern generalises with AutoGen's tool-registration surface.