### PR TITLE
docs(examples): add AutoGen multi-agent payment example (closes #7)

### DIFF
--- a/examples/autogen/README.md
+++ b/examples/autogen/README.md
@@ -1,0 +1,91 @@
+# AutoGen × MoltPe — multi-agent payments via MCP
+
+Two Microsoft AutoGen agents (an **earner** and a **payer**) transacting
+through the MoltPe MCP server without human intervention. The earner
+issues an invoice, the payer checks its balance and settles via stablecoin
+USDC on the base chain — all over the same MCP surface a single LangChain
+agent uses in [`examples/langchain/`](../langchain/README.md).
+
+Closes [#7](https://github.com/umangbuilds/moltpe-agent-payments/issues/7).
+
+## What it shows
+
+Multi-agent payment flow as a `RoundRobinGroupChat`:
+
+1. **earner** (`agent-bob`) calls `create_invoice` and posts the invoice ID.
+2. **payer** (`agent-alice`) reads the invoice from the chat, calls
+   `check_balance` to confirm it can cover the amount, then `send_payment`
+   on the stablecoin provider (base chain) to settle.
+3. Termination triggers on `DONE_PAYER` token (or a 20-message cap).
+
+This is the core "core use case" the issue calls out: two agents
+transacting with no human in the loop.
+
+## Setup (under 5 minutes)
+
+### 1. Start the MoltPe MCP server (mock mode)
+
+In one terminal:
+
+```bash
+cd ../../mcp-server
+npm install
+PROVIDER_MODE=mock npm start -- --provider all
+```
+
+Listens on `http://localhost:3000/` with seeded mock balances for
+`agent-alice`, `agent-bob`, `agent-charlie`.
+
+### 2. Install Python deps and run the example
+
+In another terminal:
+
+```bash
+cd examples/autogen
+pip install -r requirements.txt
+export OPENAI_API_KEY=sk-...
+python main.py
+```
+
+Console output streams every tool call and chat turn so the multi-agent
+payment flow is visible end-to-end.
+
+## Configuration
+
+| Env var            | Default                  | Purpose                                            |
+| ------------------ | ------------------------ | -------------------------------------------------- |
+| `MOLTPE_MCP_URL`   | `http://localhost:3000/` | MCP server endpoint                                 |
+| `EARNER_ID`        | `agent-bob`              | Service provider — issues the invoice              |
+| `PAYER_ID`         | `agent-alice`            | Customer — settles the invoice                     |
+| `INVOICE_AMOUNT`   | `25`                     | Invoice amount                                     |
+| `INVOICE_CURRENCY` | `USDC`                   | Invoice currency                                   |
+| `OPENAI_MODEL`     | `gpt-4o-mini`            | LLM model name                                     |
+| `OPENAI_API_KEY`   | (required)               | LLM credentials                                    |
+
+> The MoltPe payment side runs without credentials in mock mode. The
+> `OPENAI_API_KEY` is only for the model that drives both AutoGen agents.
+
+## Files
+
+- `main.py` — async `RoundRobinGroupChat` between earner and payer,
+  tools loaded via `autogen_ext.tools.mcp.mcp_server_tools` over a
+  Streamable-HTTP MCP transport.
+- `requirements.txt` — `autogen-agentchat`, `autogen-ext[openai,mcp]`.
+
+## Acceptance-criteria mapping (issue #7)
+
+- [x] **Two AutoGen agents: one earning, one paying** — `earner` and
+      `payer` AssistantAgents in a RoundRobinGroupChat.
+- [x] **Demonstrates agent-to-agent payment flow through MoltPe** —
+      invoice creation by earner → balance check + stablecoin send by
+      payer, all via MCP.
+- [x] **Placed in `examples/autogen/`** — alongside the LangChain example.
+- [x] **Works with mock provider** — no real funds, no real settlement.
+
+## See also
+
+- [`examples/langchain/`](../langchain/README.md) — single-agent
+  LangChain ReAct over the same MCP tools (closes #6).
+- `mcp-server/tools/index.js` — the 11 MCP tools both examples consume.
+- `mcp-server/providers/seed-data.js` — the seeded `alice` / `bob` /
+  `charlie` agents both examples default to.

--- a/examples/autogen/main.py
+++ b/examples/autogen/main.py
@@ -1,0 +1,116 @@
+"""AutoGen multi-agent payment flow over MoltPe MCP tools.
+
+Two AutoGen agents transact through MoltPe without human intervention:
+
+- ``earner`` calls ``create_invoice`` and reports the invoice ID.
+- ``payer`` reads the conversation, calls ``check_balance``, then
+  ``send_payment`` to settle the invoice.
+
+The MCP tool surface is the same one a LangChain agent would see (#6) —
+this example focuses on AutoGen's group-chat orchestration over a shared
+tool surface so the multi-agent payment flow is visible end-to-end.
+
+Designed to run against the mock provider — no real funds, no real
+settlement. Set ``OPENAI_API_KEY`` (or swap the model client below) and
+go.
+
+Usage:
+    # 1. Start the MoltPe MCP server in another terminal:
+    cd ../../mcp-server
+    PROVIDER_MODE=mock npm start -- --provider all
+
+    # 2. Run this example:
+    pip install -r requirements.txt
+    export OPENAI_API_KEY=...
+    python main.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+from autogen_agentchat.agents import AssistantAgent
+from autogen_agentchat.conditions import TextMentionTermination, MaxMessageTermination
+from autogen_agentchat.teams import RoundRobinGroupChat
+from autogen_agentchat.ui import Console
+from autogen_ext.models.openai import OpenAIChatCompletionClient
+from autogen_ext.tools.mcp import StreamableHttpServerParams, mcp_server_tools
+
+MCP_URL = os.environ.get("MOLTPE_MCP_URL", "http://localhost:3000/")
+EARNER_ID = os.environ.get("EARNER_ID", "agent-bob")
+PAYER_ID = os.environ.get("PAYER_ID", "agent-alice")
+INVOICE_AMOUNT = os.environ.get("INVOICE_AMOUNT", "25")
+INVOICE_CURRENCY = os.environ.get("INVOICE_CURRENCY", "USDC")
+MODEL = os.environ.get("OPENAI_MODEL", "gpt-4o-mini")
+
+
+EARNER_SYSTEM = (
+    f"You are agent `{EARNER_ID}`, a service provider. Your job in this "
+    "conversation is to create one invoice for the work you just delivered. "
+    "Use the `create_invoice` MCP tool. Bill it to "
+    f"`{PAYER_ID}` for {INVOICE_AMOUNT} {INVOICE_CURRENCY} with description "
+    "'API access — May 2026'. Once the invoice is created, post the invoice "
+    "ID in the chat so the payer can settle it. After that, end your turn "
+    "with the literal token DONE_EARNER on its own line."
+)
+
+PAYER_SYSTEM = (
+    f"You are agent `{PAYER_ID}`, the customer. When the earner posts an "
+    "invoice, first call `check_balance` to confirm you can cover it, then "
+    "call `send_payment` from your account to the earner via the stablecoin "
+    f"provider on the base chain ({INVOICE_AMOUNT} {INVOICE_CURRENCY}). "
+    "When the payment goes through, post a one-line summary of the "
+    "transaction (amount + recipient + status) and end your turn with the "
+    "literal token DONE_PAYER on its own line."
+)
+
+
+async def run() -> None:
+    if not os.environ.get("OPENAI_API_KEY"):
+        raise RuntimeError(
+            "OPENAI_API_KEY is required for the LLM driving the AutoGen "
+            "agents. The MoltPe MCP server itself runs in mock mode without "
+            "credentials."
+        )
+
+    server_params = StreamableHttpServerParams(url=MCP_URL)
+    tools = await mcp_server_tools(server_params)
+    print(f"Loaded {len(tools)} MoltPe MCP tools for AutoGen agents:")
+    for t in tools:
+        # AutoGen tool wrappers expose .name and .description
+        print(f"  • {t.name} — {t.description[:80]}")
+    print()
+
+    model_client = OpenAIChatCompletionClient(model=MODEL)
+
+    earner = AssistantAgent(
+        name="earner",
+        model_client=model_client,
+        tools=tools,
+        system_message=EARNER_SYSTEM,
+        reflect_on_tool_use=True,
+    )
+
+    payer = AssistantAgent(
+        name="payer",
+        model_client=model_client,
+        tools=tools,
+        system_message=PAYER_SYSTEM,
+        reflect_on_tool_use=True,
+    )
+
+    # End once both agents declare done OR after a hard message cap.
+    termination = TextMentionTermination("DONE_PAYER") | MaxMessageTermination(20)
+    team = RoundRobinGroupChat([earner, payer], termination_condition=termination)
+
+    task = (
+        f"Earner ({EARNER_ID}) just delivered API access for May 2026. "
+        f"Issue an invoice to {PAYER_ID} for {INVOICE_AMOUNT} {INVOICE_CURRENCY}, "
+        f"then have {PAYER_ID} settle it via stablecoin on base."
+    )
+    await Console(team.run_stream(task=task))
+
+
+if __name__ == "__main__":
+    asyncio.run(run())

--- a/examples/autogen/requirements.txt
+++ b/examples/autogen/requirements.txt
@@ -1,0 +1,2 @@
+autogen-agentchat>=0.4.0
+autogen-ext[openai,mcp]>=0.4.0


### PR DESCRIPTION
## Summary

Closes #7. Companion to #16 (LangChain) — same MCP surface, two cooperating agents.

Adds `examples/autogen/` with two AutoGen `AssistantAgent`s in a `RoundRobinGroupChat`:

- **earner** (`agent-bob`) calls `create_invoice` and posts the invoice ID.
- **payer** (`agent-alice`) reads the invoice from chat, calls `check_balance`, then `send_payment` via the stablecoin provider on base.
- Termination on `DONE_PAYER` token or a 20-message cap.

This is the multi-agent payment flow the issue's *Why this matters* section calls out — two agents transacting without a human in the loop.

## What's in the directory

| File | Purpose |
|---|---|
| `main.py` | Async entry point. Loads tools via `autogen_ext.tools.mcp.mcp_server_tools` + `StreamableHttpServerParams`, builds the two-agent group chat. |
| `requirements.txt` | `autogen-agentchat`, `autogen-ext[openai,mcp]`. |
| `README.md` | Setup, env-var table, acceptance-criteria mapping, cross-link to the LangChain example. |

## Decisions worth flagging

- **Defaults to seeded agents and a real invoice amount.** `EARNER_ID=agent-bob`, `PAYER_ID=agent-alice`, 25 USDC on base. `agent-alice` has 50 USDC seeded on base in `mcp-server/providers/seed-data.js`, so the payment goes through cleanly on first run.
- **Streamable HTTP transport.** Same one the LangChain example consumes. `autogen-ext[mcp]` exposes `StreamableHttpServerParams` for this.
- **`reflect_on_tool_use=True`** on both agents so each one summarises its tool result back to the chat. Without it, the earner posts the invoice but the payer can't pick the invoice ID out of the conversation.
- **Termination guard.** Two conditions OR'd: `TextMentionTermination("DONE_PAYER")` for the happy path, `MaxMessageTermination(20)` so a stuck or chatty turn doesn't burn tokens forever.

## Acceptance-criteria check

- [x] Two AutoGen agents — earner + payer.
- [x] Demonstrates agent-to-agent payment flow through MoltPe.
- [x] Placed in `examples/autogen/`.
- [x] Works with mock provider — no real funds.

## Tested

Syntax-checked locally; the MoltPe MCP server smoke-tested via `tools/list` + `tools/call` round-trips in the #16 PR (11 tools listed, `check_balance` returns seeded balances). Couldn't run the full end-to-end LLM trace without an OPENAI_API_KEY in this env — flagging that explicitly so reviewers exercise the LLM round-trip.

Sister PR #16 ships the LangChain counterpart for #6.